### PR TITLE
chore: delete old assets when uploading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run:
           name: Upload artifacts
           command: |
-            gsutil rsync -r -x "gcpv.*\.json" ~/project/dist gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static
+            gsutil rsync -d -r -x "gcpv.*\.json" ~/project/dist gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static
 
 workflows:
   ci:


### PR DESCRIPTION
rsync with `-d` looks something like this (also added `-n` for this output):

```
Building synchronization state...
Starting synchronization...
Would copy file://dist/assets/bugzilla-XGfJrhs1.png to gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/bugzilla-XGfJrhs1.png
Would copy file://dist/assets/dawg-BW3-w7UP.svg to gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/dawg-BW3-w7UP.svg
Would copy file://dist/assets/gcp-eCM6l0lH.png to gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/gcp-eCM6l0lH.png
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-B0Y8f-vk.css

==> NOTE: You are performing a sequence of gsutil operations that may
run significantly faster if you instead use gsutil -m rsync ... Please
see the -m section under "gsutil help options" for further information
about when gsutil -m can be advantageous.

Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-B40cU0Wd.css
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-BCRAxOz5.css
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-BUirUec_.css
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-BXFKkgbK.js
Would copy file://dist/assets/index-BpNIsjFn.js to gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-BpNIsjFn.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-C0tkusoT.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-CDqc7DCu.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-CTkVBqgj.css
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-CZmQkVkC.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-Cj2SgwdC.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-CmG3sVdL.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-CvatmnPl.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-DAUQULf-.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-DWyjxe05.css
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-Dmnytgw6.css
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-DpEioUBw.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-DxZ0ppve.js
Would copy file://dist/assets/index-H69ti2xj.css to gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-H69ti2xj.css
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-IfhlLDmd.css
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-RDeyAwR2.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-SGJAA4fy.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-c-wrAGFn.js
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-oNkZe-eM.css
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/assets/index-tUXudMuz.css
Would copy file://dist/favicon.ico to gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/favicon.ico
Would copy file://dist/index.html to gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/index.html
Would remove gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/mock.json
Would copy file://dist/mockdata.json to gs://moz-fx-data-prot-nonprod-c3a1-protodash/dawg/static/mockdata.json
```