### PR TITLE
feat: fixes issue #18

### DIFF
--- a/src/components/DAWGTableCell.vue
+++ b/src/components/DAWGTableCell.vue
@@ -6,8 +6,7 @@ import type { DAWG, ListOfText, MapOfLists, PlainText } from '@/workgroups'
 
 import IconLink from './IconLink.vue';
 import AutoLinker from './AutoLinker.vue';
-
-
+import { computed } from 'vue';
 
 const props = defineProps<{
     contents: undefined | PlainText | ListOfText | MapOfLists,
@@ -15,8 +14,6 @@ const props = defineProps<{
 }>()
 
 const display = getFieldDisplayMode(props.fieldName)
-
-
 </script>
 
 <template>
@@ -45,16 +42,26 @@ const display = getFieldDisplayMode(props.fieldName)
             <AutoLinker :text="props.contents && (props.contents as ListOfText)[0]" />
         </span>
         <dl v-else-if="display === DisplayMode.MapOfLists">
+
+            <ul v-if="(props.contents as MapOfLists).hasOwnProperty('default')">
+                <li v-for="member in (props.contents as MapOfLists).default" :key="member">
+                    {{ member }}
+                </li>
+            </ul>
+
             <template v-for="(list, key) in (props.contents as MapOfLists)" :key="key">
-                <dt>{{ key }}</dt>
-                <dd>
-                    <ul v-if="list.length > 0">
-                        <li v-for="item, i in list" :key="i">
-                            <AutoLinker :text="item" />
-                        </li>
-                    </ul>
-                    <span v-else>(no members)</span>
-                </dd>
+                <template v-if="key != 'default'">
+                    <dt>{{ key }}</dt>
+                    <dd>
+                        <ul v-if="list.length > 0">
+                            <li v-for="item, i in list" :key="i">
+                                <AutoLinker :text="item" />
+                            </li>
+                        </ul>
+                        <span v-else>(no members)</span>
+                    </dd>
+                </template>
+
             </template>
         </dl>
     </td>

--- a/src/components/DAWGTableCell.vue
+++ b/src/components/DAWGTableCell.vue
@@ -51,7 +51,7 @@ const display = getFieldDisplayMode(props.fieldName)
 
             <template v-for="(list, key) in (props.contents as MapOfLists)" :key="key">
                 <template v-if="key != 'default'">
-                    <dt>{{ key }}</dt>
+                    <dt class="monospace">{{ key }}</dt>
                     <dd>
                         <ul v-if="list.length > 0">
                             <li v-for="item, i in list" :key="i">

--- a/src/workgroups.ts
+++ b/src/workgroups.ts
@@ -69,22 +69,25 @@ export const getFieldDisplayMode = (f: keyof DAWG): DisplayMode => {
 
 const copy = (o: any) => JSON.parse(JSON.stringify(o))
 export const formatDAWGID = (name: string) => `workgroup:${name}`
-export const newWorkGroup = (groupname: string, kind: DAWGKind, data: any): DAWG => {
-  const defaultWorkGroupIDs = [
-    '_default',
-    'analysis-writer',
-    'udf',
-    'udf-writer',
-    'team',
-    'default-compute',
-    'syndicate',
-    'syndicated',
-    'unmanaged',
-    'client-managed',
-    'application',
-    'application-noanalysis'
-  ]
+const defaultWorkGroupIDs = [
+  '_default',
+  'analysis-writer',
+  'udf',
+  'udf-writer',
+  'team',
+  'default-compute',
+  'syndicate',
+  'syndicated',
+  'unmanaged',
+  'client-managed',
+  'application',
+  'application-noanalysis'
+]
+const filterDefaultWorkgroups = (key: string) => !defaultWorkGroupIDs.includes(key)
+const transformSubGroupIDs = (wgID: string, subID: string) =>
+  subID != 'default' ? `${wgID}/${subID}` : subID
 
+export const newWorkGroup = (groupname: string, kind: DAWGKind, data: any): DAWG => {
   const wg = copy(NullWorkGroup)
   wg.id = formatDAWGID(groupname)
   wg.kind = kind
@@ -105,7 +108,11 @@ export const newWorkGroup = (groupname: string, kind: DAWGKind, data: any): DAWG
 
   if (Object.keys(data?.members).length > 0)
     wg.members = Object.fromEntries(
-      Object.entries(data?.members).filter(([key]) => !defaultWorkGroupIDs.includes(key))
+      Object.entries(data?.members)
+        .filter(([key]) => filterDefaultWorkgroups(key))
+        .map(([key, value]) => {
+          return [transformSubGroupIDs(wg.id, key), value]
+        })
     )
 
   return wg


### PR DESCRIPTION
- Loads subgroups w/ full canonical ids (except for the default subgroup) to fix search issued raised in #18 
- If present, the default "subgroup" members are now shown first w/o a subgroup name shown since they are direct members of the workgroup and not truly in a subgroup. 
- subgroup names are shown in monospace font for clarity (as you wish @whd )