### PR TITLE
chore:simplify build options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,13 @@ jobs:
       - store_test_results:
           path: ./test-results/e2e-results.xml
 
-  type-check:
+  test-types:
     executor:
       name: pw-jammy-development
     steps:
       - checkout
       - node/install-packages
-      - run: npm run type-check
+      - run: npm run test:types
 
   build:
     executor:
@@ -93,7 +93,7 @@ workflows:
   ci:
     jobs:
       - lint
-      - type-check
+      - test-types
       - test-unit
       - test-e2e
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - checkout
       - node/install-packages
-      - run: npm run build-only -- --mode development
+      - run: npm run build -- --mode development
       - run:
           command: npm run test:e2e
           environment:
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Build assets
           command: |
-            npm run build-only -- --base="/dawg/"
+            npm run build -- --base="/dawg/"
       - persist_to_workspace:
           root: ~/project
           paths:

--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "test": "run-p test:unit test:e2e",
     "test:unit": "vitest run",
     "test:e2e": "playwright test",
-    "build-only": "vite build",
+    "build": "vite build",
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "format": "prettier --write src/"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test": "run-p test:unit test:e2e",
     "test:unit": "vitest run",
     "test:e2e": "playwright test",
+    "test:types": "vue-tsc --build --force",
     "build": "vite build",
-    "type-check": "vue-tsc --build --force",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "format": "prettier --write src/"
   },


### PR DESCRIPTION
Choring that clean ups some NPM scripts and corresponding Circle CI steps

We are manually type checking already so I removed the combo step "build" which was type checking and building (and making passes build args more challenging) and simplified to have only`build` 

For consistency I also moved `type-check` to `test:types` to align w/ `test:e2e` and `test:unit` scripts